### PR TITLE
Prevent to draw null-character at the end of each string.

### DIFF
--- a/desktop/glfw_gui/c/jni_nanovg.c
+++ b/desktop/glfw_gui/c/jni_nanovg.c
@@ -2102,7 +2102,7 @@ int org_mini_nanovg_Nanovg_nvgTextJni(Runtime *runtime, JClass *clazz) {
     s32 pstart = env->localvar_getInt(runtime->localvar, pos++);
     s32 pend = env->localvar_getInt(runtime->localvar, pos++);
 
-    f32 ret_value = (f32)nvgTextJni((NVGcontext*/*ptr*/)(pctx), (float)px.f, (float)py.f, (const char*)(ptr_pstring), (int)pstart, (int)pend);
+    f32 ret_value = (f32)nvgTextJni((NVGcontext*/*ptr*/)(pctx), (float)px.f, (float)py.f, (const char*)(ptr_pstring), (int)pstart, (int)pend-1);
     env->push_float(runtime->stack, ret_value);
     
     return 0;


### PR DESCRIPTION
Using a different font all GLabel and GButton and other objects draws an unknown character [X] at the end of each font-string.
The used default-font seems to draw a null-character with nothing instead.
As it is not necessary to draw the null-character we can and should skip it.